### PR TITLE
Show hints in CODAP WebView; move back a step after consecutive poor scores

### DIFF
--- a/js/codap-handler.js
+++ b/js/codap-handler.js
@@ -132,6 +132,45 @@ export function generateCodapData (options) {
   return values
 }
 
+let randomSuffix = Math.round(Math.random() * 1000000000)
+
+function _createWebView (options) {
+  return codapInterface.sendRequest({
+    action: 'create',
+    resource: 'component',
+    values: {
+      type: 'webView',
+      name: `rampGameHints-${++randomSuffix}`,
+      title: options.title || '',
+      dimensions: {
+        width: options.width || 345,
+        height: options.height || 345
+      },
+      position: 'top',
+      URL: options.URL
+    }
+  })
+}
+
+export function showWebView (options) {
+  return codapInterface.sendRequest({
+    action: 'update',
+    resource: `component[rampGameHints-${randomSuffix}]`,
+    values: options
+  }, function (response) {
+    if (!response.success) {
+      _createWebView(options)
+    }
+  })
+}
+
+export function hideWebView (options) {
+  return codapInterface.sendRequest({
+    action: 'delete',
+    resource: `component[rampGameHints-${randomSuffix}]`
+  })
+}
+
 function generateCompleteData (options) {
   const data = []
   const optionsCopy = Object.assign({}, options)

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,11 @@
+import { showWebView } from './codap-handler'
+
+export const MIN_SCORE_TO_AVOID_REMEDIATION = 1
+export const MIN_SCORE_TO_AVOID_HINTS = 25
 export const MIN_SCORE_TO_ADVANCE = 33
 export const GAME_INPUTS = ['surfaceFriction']
 export const GAME_OUTPUTS = ['startHeightAboveGround', 'startDistanceUpRamp', 'currentEndDistance']
+const HINT_COMPONENT_TITLE = 'Ramp Game Hints'
 
 export function calcGameScore (carX, targetX, targetWidth) {
   const targetRadius = 0.5 * targetWidth
@@ -49,6 +54,17 @@ export const challenges = [
     },
     targetWidth (step) {
       return 0.9 - step * 0.14
+    },
+    hint (state) {
+      if (state.runsInStep >= 3) {
+        showWebView({
+          title: HINT_COMPONENT_TITLE,
+          URL: 'https://inquiryspace-resources.concord.org/ramp-game-hints/challange2-make-a-graph.html'
+        })
+      }
+    },
+    loseStep (state) {
+      return state.remedialScores >= 3
     }
   },
   {
@@ -63,6 +79,17 @@ export const challenges = [
     },
     targetWidth (step) {
       return 0.9 - step * 0.14
+    },
+    hint (state) {
+      if (state.hintableScores >= 3) {
+        showWebView({
+          title: HINT_COMPONENT_TITLE,
+          URL: 'https://inquiryspace-resources.concord.org/ramp-game-hints/challange3-movable-line.html'
+        })
+      }
+    },
+    loseStep (state) {
+      return state.remedialScores >= 3
     }
   },
   {
@@ -78,6 +105,24 @@ export const challenges = [
     },
     targetWidth (step) {
       return 0.9 - step * 0.14
+    },
+    hint (state) {
+      const urls = [
+        'https://inquiryspace-resources.concord.org/ramp-game-hints/challange4-axis-legend-selection.html',
+        'https://inquiryspace-resources.concord.org/ramp-game-hints/challange4-axis-selection.html',
+        'https://inquiryspace-resources.concord.org/ramp-game-hints/challange4-legend-selection.html',
+        'https://inquiryspace-resources.concord.org/ramp-game-hints/challange4-selection.html'
+      ]
+      const randomIndex = Math.floor(Math.random() * urls.length)
+      if (state.hintableScores >= 3) {
+        showWebView({
+          title: HINT_COMPONENT_TITLE,
+          URL: urls[randomIndex]
+        })
+      }
+    },
+    loseStep (state) {
+      return state.remedialScores >= 3
     }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "This project reproduces the Inquiry Space car ramp challenge in Javascript",
   "main": "js/index.js",
   "scripts": {
-    "lint": "standard --fix"
+    "build": "webpack",
+    "deploy": "./build_and_deploy.sh",
+    "lint": "standard --fix",
+    "start": "webpack-dev-server"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Show hints in CODAP WebView during game [#151024072]
- Move back a step within the challenge after three consecutive poor scores [#151024189]
- Add npm scripts `build`, `deploy`, `start`

Note: the hint behavior relies on CODAP PR [#200](https://github.com/concord-consortium/codap/pull/200).

@pjanik Feel free to review if you're so inclined, but don't feel obligated if you're already on vacation. :wink: