### PR TITLE
Adjust layout of car crash instructions

### DIFF
--- a/css/car-crash-instructions.less
+++ b/css/car-crash-instructions.less
@@ -1,7 +1,7 @@
 .wrapper {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  flex-direction: row;
+  justify-content: left;
   align-items: center;
   overflow: hidden;
 }
@@ -12,6 +12,6 @@
   margin-bottom: 1em;
   max-width: 610px;
   margin-left: 0px;
-  margin-right: 0px;
+  margin-right: 10px;
   padding: 0px;
 }

--- a/css/car-crash.less
+++ b/css/car-crash.less
@@ -18,3 +18,7 @@
   }
 
 }
+
+.wideDialog {
+  width: 96vw;
+}

--- a/js/components/car-crash.js
+++ b/js/components/car-crash.js
@@ -102,6 +102,7 @@ export default class CarCrash extends SimulationBase {
           onEscKeyDown={this.hideDialog}
           onOverlayClick={this.hideDialog}
           title='Instructions'
+          className={crashStyles.wideDialog}
         >
           <Instructions />
         </Dialog>


### PR DESCRIPTION
The car crash interactive is best utilized in a long and short window. That didn't work so well with the default dialog dimensions, so this adjusts that, and also puts the instructions to the left of the image rather than on top of it.